### PR TITLE
Add ACAT 2025 and CHEP 2026 talks

### DIFF
--- a/index.md
+++ b/index.md
@@ -68,6 +68,8 @@ JuliaHEP is also one of the activities of the HEP Software Foundation ([HSF](htt
 
 ### Talks
 
+- Performance and integration challenges of using Julia language for trigger and reconstruction (CHEP 2026, [by Mateusz Fila](https://indico.cern.ch/event/1471803/contributions/6966827/))
+- Static compilation of Julia packages for integration with existing HEP codebases: a case study with JetReconstruction.jl (ACAT 2025, [by Mateusz Fila](https://indico.cern.ch/event/1488410/contributions/6562804/))
 - Julia in HEP? (CHEP 2024, Plenary, [by Graeme A Stewart](https://indico.cern.ch/event/1338689/contributions/6009700/))
 - Julia in high-energy physics: a paradigm shift or just another tool?, HSF Seminar, October 2024 [by Uwe Hernandez Acosta](https://indico.cern.ch/event/1452314/)
 - Julia for HEP Computation (CoDaS-HEP/PyHEP 2023, [by Jerry Ling](https://indico.cern.ch/event/1293313/timetable/#11-hands-on-demo-session))

--- a/index.md
+++ b/index.md
@@ -68,10 +68,9 @@ JuliaHEP is also one of the activities of the HEP Software Foundation ([HSF](htt
 
 ### Talks
 
-- Julia in HEP?, Computing in High Energy and Nucelar Physics Plenary, October 2024 [by Graeme A Stewart](https://indico.cern.ch/event/1338689/contributions/6009700/)
+- Julia in HEP? (CHEP 2024, Plenary, [by Graeme A Stewart](https://indico.cern.ch/event/1338689/contributions/6009700/))
 - Julia in high-energy physics: a paradigm shift or just another tool?, HSF Seminar, October 2024 [by Uwe Hernandez Acosta](https://indico.cern.ch/event/1452314/)
-- Julia for HEP Computation (CoDaS-HEP/PyHEP 2023, [by Jerry
-   Ling](https://indico.cern.ch/event/1293313/timetable/#11-hands-on-demo-session))
+- Julia for HEP Computation (CoDaS-HEP/PyHEP 2023, [by Jerry Ling](https://indico.cern.ch/event/1293313/timetable/#11-hands-on-demo-session))
 - Is Julia ready to be adopted by HEP? (CHEP2023, [by Tamás Gál](https://indico.jlab.org/event/459/contributions/11521/))
 - High-performance end-user analysis in pure Julia programming language (CHEP2023, [by Jerry Ling](https://indico.jlab.org/event/459/contributions/11560/))
 - Polyglot Jet Finding (CHEP2023, [by Graeme A Stewart](https://indico.jlab.org/event/459/contributions/11540/))


### PR DESCRIPTION
Adding my talks from ACAT 2025 (static compilation) and CHEP 2026 (summary of projects trying to use Julia in place of C++)
Also changed formatting for Graeme's CHEP 2024 plenary talk so it's consistent with the rest.